### PR TITLE
Check (shared) file exists

### DIFF
--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -68,7 +68,7 @@ task('deploy:shared', function () {
         run("if [ ! -d $(echo {{release_path}}/$dirname) ]; then mkdir -p {{release_path}}/$dirname;fi");
 
         // Touch shared
-        run("touch $sharedPath/$file");
+        run("[[ -f $sharedPath/$file ]] || touch $sharedPath/$file");
 
         // Symlink shared dir to release dir
         run("{{bin/symlink}} $sharedPath/$file {{release_path}}/$file");


### PR DESCRIPTION
Doing a check if the shared file already exists.
A touch could result in a 'Permission denied' causing the deploy to stop.